### PR TITLE
Fix: User input text is lost on screen rotation

### DIFF
--- a/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentDemoScreen.kt
+++ b/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentDemoScreen.kt
@@ -232,7 +232,9 @@ fun AgentDemoLoadedScreen(
     messageText: String = "",
     initialSidePanelVisible: Boolean = false,
 ) {
-    var messageText by remember { mutableStateOf(TextFieldValue("")) }
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(messageText, TextRange(messageText.length)))
+    }
     var isSidePanelVisible by remember { mutableStateOf(initialSidePanelVisible) }
     var selectedAppPackageName by remember { mutableStateOf<String?>(null) }
 
@@ -345,15 +347,15 @@ fun AgentDemoLoadedScreen(
                 }
 
                 val sendMessage = {
-                    val textStr = messageText.text
+                    val textStr = textFieldValue.text
                     if (textStr.isNotBlank() && uiState.status == AgentStatus.Idle) {
                         onEvent(AgentUiEvent.OnSendMessage(textStr, selectedAppPackageName))
-                        messageText = TextFieldValue("")
+                        textFieldValue = TextFieldValue("")
                         selectedAppPackageName = null
                     }
                 }
 
-                val textStr = messageText.text
+                val textStr = textFieldValue.text
                 val lastAtIndex = textStr.lastIndexOf('@')
                 val showAutocomplete =
                     lastAtIndex >= 0 &&
@@ -409,9 +411,10 @@ fun AgentDemoLoadedScreen(
                 // Input area
                 Box(modifier = Modifier.fillMaxWidth()) {
                     OutlinedTextField(
-                        value = messageText,
+                        value = textFieldValue,
                         onValueChange = { newValue ->
-                            messageText = newValue
+                            textFieldValue = newValue
+                            onEvent(AgentUiEvent.OnMessageTextChanged(newValue.text))
                             val currentText = newValue.text
                             if (selectedAppPackageName != null && appMentionRegex != null) {
                                 if (!appMentionRegex.containsMatchIn(currentText)) {
@@ -449,7 +452,7 @@ fun AgentDemoLoadedScreen(
                             IconButton(
                                 onClick = sendMessage,
                                 enabled =
-                                    messageText.text.isNotBlank() &&
+                                    textFieldValue.text.isNotBlank() &&
                                         uiState.status == AgentStatus.Idle,
                             ) {
                                 Icon(
@@ -481,8 +484,8 @@ fun AgentDemoLoadedScreen(
                                         DropdownMenuItem(
                                             text = { Text(app.label) },
                                             onClick = {
-                                                val currentText = messageText.text
-                                                val selectionStart = messageText.selection.start
+                                                val currentText = textFieldValue.text
+                                                val selectionStart = textFieldValue.selection.start
                                                 val textBeforeCursor =
                                                     currentText.take(
                                                         selectionStart,
@@ -502,7 +505,7 @@ fun AgentDemoLoadedScreen(
                                                         "$textBeforeMention@${app.label} $textAfterCursor"
                                                     val newCursorPosition =
                                                         mentionIndex + app.label.length + 2
-                                                    messageText =
+                                                    textFieldValue =
                                                         TextFieldValue(
                                                             text = newText,
                                                             selection =
@@ -510,6 +513,9 @@ fun AgentDemoLoadedScreen(
                                                                     newCursorPosition,
                                                                 ),
                                                         )
+                                                    onEvent(
+                                                        AgentUiEvent.OnMessageTextChanged(newText),
+                                                    )
                                                     selectedAppPackageName = app.packageName
                                                 }
                                             },

--- a/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentDemoScreen.kt
+++ b/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentDemoScreen.kt
@@ -107,8 +107,13 @@ import kotlinx.coroutines.launch
 @Composable
 fun AgentDemoScreen(viewModel: AgentDemoViewModel = hiltViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val messageText by viewModel.messageText.collectAsStateWithLifecycle()
 
-    AgentDemoContent(uiState = uiState, onEvent = viewModel::onEvent)
+    AgentDemoContent(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+        messageText = messageText,
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -116,6 +121,7 @@ fun AgentDemoScreen(viewModel: AgentDemoViewModel = hiltViewModel()) {
 fun AgentDemoContent(
     uiState: AgentUiState,
     onEvent: (AgentUiEvent) -> Unit,
+    messageText: String = "",
     initialSidePanelVisible: Boolean = false,
 ) {
     val context = LocalContext.current
@@ -144,6 +150,7 @@ fun AgentDemoContent(
                         drawerState = drawerState,
                         scope = scope,
                         packageManager = packageManager,
+                        messageText = messageText,
                         initialSidePanelVisible = initialSidePanelVisible,
                     )
                 }
@@ -194,9 +201,9 @@ fun AgentDemoLoadedScreen(
     drawerState: DrawerState,
     scope: CoroutineScope,
     packageManager: PackageManager,
+    messageText: String = "",
     initialSidePanelVisible: Boolean = false,
 ) {
-    var messageText by remember { mutableStateOf("") }
     var isSidePanelVisible by remember { mutableStateOf(initialSidePanelVisible) }
 
     Scaffold(
@@ -292,14 +299,13 @@ fun AgentDemoLoadedScreen(
                 val sendMessage = {
                     if (messageText.isNotBlank() && uiState.status == AgentStatus.Idle) {
                         onEvent(AgentUiEvent.OnSendMessage(messageText))
-                        messageText = ""
                     }
                 }
 
                 // Input area
                 OutlinedTextField(
                     value = messageText,
-                    onValueChange = { messageText = it },
+                    onValueChange = { onEvent(AgentUiEvent.OnMessageTextChanged(it)) },
                     modifier =
                         Modifier.fillMaxWidth().padding(vertical = 16.dp).onPreviewKeyEvent {
                                 keyEvent ->

--- a/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentDemoViewModel.kt
+++ b/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentDemoViewModel.kt
@@ -61,6 +61,9 @@ class AgentDemoViewModel
         private val _uiState = MutableStateFlow<AgentUiState>(AgentUiState.Loading)
         val uiState: StateFlow<AgentUiState> = _uiState.asStateFlow()
 
+        val messageText: StateFlow<String> =
+            savedStateHandle.getStateFlow(KEY_MESSAGE_TEXT, "")
+
         private var observationJob: Job? = null
 
         init {
@@ -149,6 +152,7 @@ class AgentDemoViewModel
             val currentState = _uiState.value
             when (event) {
                 is AgentUiEvent.OnSendMessage -> {
+                    savedStateHandle[KEY_MESSAGE_TEXT] = ""
                     if (currentState is AgentUiState.Loaded) {
                         viewModelScope.launch {
                             sendMessageUseCase(
@@ -159,6 +163,9 @@ class AgentDemoViewModel
                             )
                         }
                     }
+                }
+                is AgentUiEvent.OnMessageTextChanged -> {
+                    savedStateHandle[KEY_MESSAGE_TEXT] = event.text
                 }
                 is AgentUiEvent.OnModelSelected -> {
                     if (currentState is AgentUiState.Loaded) {
@@ -190,6 +197,8 @@ class AgentDemoViewModel
             savedStateHandle[MainActivity.ARG_THREAD_ID] = threadId
         }
     }
+
+private const val KEY_MESSAGE_TEXT = "messageText"
 
 private data class ThreadConfig(
     val threads: List<ThreadEntity>,

--- a/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentUiState.kt
+++ b/agent/app/src/main/java/com/example/appfunctions/agent/ui/screens/agentdemo/AgentUiState.kt
@@ -44,4 +44,6 @@ sealed class AgentUiEvent {
     data class OnThreadSelected(val threadId: String) : AgentUiEvent()
 
     data class OnConfirmAction(val pendingIntentId: String) : AgentUiEvent()
+
+    data class OnMessageTextChanged(val text: String) : AgentUiEvent()
 }


### PR DESCRIPTION
- Add `OnMessageTextChanged` to `AgentUiEvent` to capture user input.
- Migrate message text state from local Compose state to the ViewModel, utilizing `SavedStateHandle` for state persistence across configuration changes.

**What I have done and why**
Fix https://github.com/android/appfunctions/issues/13

Video fix:
https://github.com/user-attachments/assets/00c9b9ce-e24a-437d-bb81-e314438afe22

