### PR TITLE
Use only endpoint for sendMessage and makeCall

### DIFF
--- a/ChatApp/app/build.gradle.kts
+++ b/ChatApp/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.example.chatapp"
         minSdk = 24
         targetSdk = 37
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 99999
+        versionName = "99999"
 
         testInstrumentationRunner = "com.example.chatapp.HiltTestRunner"
     }

--- a/ChatApp/app/build.gradle.kts
+++ b/ChatApp/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.example.chatapp"
         minSdk = 24
         targetSdk = 37
-        versionCode = 99999
-        versionName = "99999"
+        versionCode = 1
+        versionName = "1.0"
 
         testInstrumentationRunner = "com.example.chatapp.HiltTestRunner"
     }

--- a/ChatApp/app/src/androidTest/kotlin/com/example/chatapp/appfunctions/AppFunctionInstrumentationTest.kt
+++ b/ChatApp/app/src/androidTest/kotlin/com/example/chatapp/appfunctions/AppFunctionInstrumentationTest.kt
@@ -82,7 +82,6 @@ class AppFunctionInstrumentationTest {
                         sendMessageFunctionMetadata.parameters,
                         sendMessageFunctionMetadata.components,
                     )
-                        .setString("name", testRecipient.name)
                         .setString("endpointValue", testRecipient.id)
                         .setString("messageBody", "Hello!")
                         .build(),
@@ -122,7 +121,6 @@ class AppFunctionInstrumentationTest {
                         sendMessageFunctionMetadata.parameters,
                         sendMessageFunctionMetadata.components,
                     )
-                        .setString("name", testRecipient.name)
                         .setString("endpointValue", testRecipient.id)
                         .setString("messageBody", "")
                         .build(),

--- a/ChatApp/app/src/androidTest/kotlin/com/example/chatapp/appfunctions/AppFunctionsTest.kt
+++ b/ChatApp/app/src/androidTest/kotlin/com/example/chatapp/appfunctions/AppFunctionsTest.kt
@@ -133,7 +133,7 @@ class AppFunctionsTest {
     @Test
     fun send_validMessage_returnsSuccess() {
         runTest {
-            val result = appFunctions.send(testContext, "Alice Smith", "1", "Hello")
+            val result = appFunctions.send(testContext, "1", "Hello")
             Assert.assertEquals(
                 AppFunctions.Result(
                     "Message ID",
@@ -150,7 +150,6 @@ class AppFunctionsTest {
             val result =
                 appFunctions.send(
                     testContext,
-                    "Alice Smith",
                     "1",
                     "Hello",
                     listOf(Uri.parse("content://media/1")),
@@ -168,7 +167,7 @@ class AppFunctionsTest {
     @Test
     fun send_toGroup_success() {
         runTest {
-            val result = appFunctions.send(testContext, "Work Friends", "g1", "Hello")
+            val result = appFunctions.send(testContext, "g1", "Hello")
             Assert.assertEquals(
                 AppFunctions.Result(
                     "Message ID",
@@ -182,14 +181,14 @@ class AppFunctionsTest {
     @Test(expected = AppFunctionInvalidArgumentException::class)
     fun send_emptyContent_fails() {
         runTest {
-            appFunctions.send(testContext, "Alice Smith", "1", "")
+            appFunctions.send(testContext, "1", "")
         }
     }
 
     @Test(expected = AppFunctionElementNotFoundException::class)
     fun send_invalidRecipient_fails() {
         runTest {
-            appFunctions.send(testContext, "Unknown", "nonexistent_id", "Hello")
+            appFunctions.send(testContext, "nonexistent_id", "Hello")
         }
     }
 
@@ -197,7 +196,7 @@ class AppFunctionsTest {
     fun send_repositoryError_returnsError() {
         runTest {
             messageRepository.shouldFail = true
-            appFunctions.send(testContext, "Alice Smith", "1", "Hello")
+            appFunctions.send(testContext, "1", "Hello")
         }
     }
 
@@ -209,27 +208,6 @@ class AppFunctionsTest {
         }
     }
 
-    @Test
-    fun makeCall_withContactName_success() {
-        runBlocking {
-            val pendingIntent = appFunctions.makeCall(testContext, contactName = "Alice Smith")
-            Assert.assertNotNull(pendingIntent)
-        }
-    }
-
-    @Test(expected = AppFunctionInvalidArgumentException::class)
-    fun makeCall_missingParameters_fails() {
-        runBlocking {
-            appFunctions.makeCall(testContext, contactName = null, endpointValue = null)
-        }
-    }
-
-    @Test(expected = AppFunctionElementNotFoundException::class)
-    fun makeCall_invalidContactName_fails() {
-        runBlocking {
-            appFunctions.makeCall(testContext, contactName = "Unknown")
-        }
-    }
 
     @Test(expected = AppFunctionElementNotFoundException::class)
     fun makeCall_invalidEndpointValue_fails() {
@@ -238,11 +216,4 @@ class AppFunctionsTest {
         }
     }
 
-    @Test(expected = AppFunctionInvalidArgumentException::class)
-    fun makeCall_duplicateContactName_fails() {
-        runBlocking {
-            // "Bob Johnson" has two entries (ID 2 and ID 7)
-            appFunctions.makeCall(testContext, contactName = "Bob Johnson")
-        }
-    }
 }

--- a/ChatApp/app/src/main/kotlin/com/example/chatapp/data/CallManager.kt
+++ b/ChatApp/app/src/main/kotlin/com/example/chatapp/data/CallManager.kt
@@ -41,9 +41,6 @@ class CallManager
                     ?: recipientsRepository.getGroupById(recipientId)?.let {
                         Recipient(it.id, it.name, "")
                     }
-                    ?: recipientsRepository.getRecipientByName(recipientId).let { list ->
-                        if (list.size == 1) list.first() else null
-                    }
                     ?: Recipient(recipientId, recipientId, "")
             startCall(recipient)
         }

--- a/ChatApp/app/src/main/res/xml/app_metadata.xml
+++ b/ChatApp/app/src/main/res/xml/app_metadata.xml
@@ -21,6 +21,6 @@ Operational Patterns:
   - Passing a blank query to 'searchContacts' retrieves the most recent contacts.
 Constraints:
   - Message content cannot be empty or blank.
-  - Calls can be initiated by either contact name or unique identifier.
+  - Calls are initiated by unique identifier.
   - Media attachments are supported via a list of URIs."
     appfn:displayDescription="@string/app_function_app_display_description"/>

--- a/ChatApp/shared/build.gradle.kts
+++ b/ChatApp/shared/build.gradle.kts
@@ -49,4 +49,7 @@ dependencies {
     implementation(libs.androidx.appfunctions)
     implementation(libs.androidx.appfunctions.service)
     ksp(libs.androidx.appfunctions.compiler)
+
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/ChatApp/shared/build.gradle.kts
+++ b/ChatApp/shared/build.gradle.kts
@@ -50,6 +50,4 @@ dependencies {
     implementation(libs.androidx.appfunctions.service)
     ksp(libs.androidx.appfunctions.compiler)
 
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/ChatApp/shared/src/main/kotlin/com/example/chatapp/ChatViewModel.kt
+++ b/ChatApp/shared/src/main/kotlin/com/example/chatapp/ChatViewModel.kt
@@ -85,9 +85,6 @@ class ChatViewModel
                 ?: recipientsRepository.getGroupById(recipientId)?.let {
                     Recipient(it.id, it.name, "")
                 }
-                ?: recipientsRepository.getRecipientByName(recipientId).let { list ->
-                    if (list.size == 1) list.first() else null
-                }
                 ?: if (recipientId == "bot") {
                     Recipient("bot", "Assistant", "bot@example.com")
                 } else {

--- a/ChatApp/shared/src/main/kotlin/com/example/chatapp/appfunctions/AppFunctions.kt
+++ b/ChatApp/shared/src/main/kotlin/com/example/chatapp/appfunctions/AppFunctions.kt
@@ -97,7 +97,6 @@ class AppFunctions
          * Send a text message with optional image attachments.
          *
          * @param appFunctionContext The context of this app function call.
-         * @param name The display name of the recipient for confirmation purposes.
          * @param endpointValue The unique identifier for the recipient or group.
          * @param messageBody The text content of the message. Cannot be empty.
          * @param imageUris List of URIs for images to attach.
@@ -105,7 +104,6 @@ class AppFunctions
         @AppFunction(isDescribedByKDoc = true)
         suspend fun send(
             appFunctionContext: AppFunctionContext,
-            name: String,
             endpointValue: String,
             messageBody: String,
             imageUris: List<Uri>? = null,
@@ -140,43 +138,18 @@ class AppFunctions
          * Initiate a voice call.
          *
          * @param appFunctionContext The context of this app function call.
-         * @param contactName The name of the contact. Use this if the ID is unknown.
          * @param endpointValue The unique identifier for the recipient.
          */
         @AppFunction(isDescribedByKDoc = true)
         suspend fun makeCall(
             appFunctionContext: AppFunctionContext,
-            contactName: String? = null,
-            endpointValue: String? = null,
+            endpointValue: String,
         ): PendingIntent {
-            if (contactName == null && endpointValue == null) {
-                throw AppFunctionInvalidArgumentException(
-                    "Specify either contactName or endpointValue. Both cannot be null.",
-                )
-            }
-
             val recipient =
-                with(recipientsRepository) {
-                    if (endpointValue == null) {
-                        val matches = getRecipientByName(checkNotNull(contactName))
-                        if (matches.isEmpty()) {
-                            throw AppFunctionElementNotFoundException(
-                                "No recipient exists for contactName: $contactName",
-                            )
-                        }
-                        if (matches.size > 1) {
-                            throw AppFunctionInvalidArgumentException(
-                                "Multiple contacts found with name $contactName. Please be more specific.",
-                            )
-                        }
-                        matches.first()
-                    } else {
-                        getRecipientById(endpointValue)
-                            ?: throw AppFunctionElementNotFoundException(
-                                "No recipient exists for endpointValue: $endpointValue",
-                            )
-                    }
-                }
+                recipientsRepository.getRecipientById(endpointValue)
+                    ?: throw AppFunctionElementNotFoundException(
+                        "No recipient exists for endpointValue: $endpointValue",
+                    )
 
             // Call manager should technically also record it here depending on app architecture,
             // but we will launch the intent to handle it in the UI.

--- a/ChatApp/shared/src/main/kotlin/com/example/chatapp/data/CallManager.kt
+++ b/ChatApp/shared/src/main/kotlin/com/example/chatapp/data/CallManager.kt
@@ -41,9 +41,6 @@ class CallManager
                     ?: recipientsRepository.getGroupById(recipientId)?.let {
                         Recipient(it.id, it.name, "")
                     }
-                    ?: recipientsRepository.getRecipientByName(recipientId).let { list ->
-                        if (list.size == 1) list.first() else null
-                    }
                     ?: Recipient(recipientId, recipientId, "")
             startCall(recipient)
         }

--- a/ChatApp/wear/build.gradle.kts
+++ b/ChatApp/wear/build.gradle.kts
@@ -69,8 +69,6 @@ dependencies {
     implementation(libs.androidx.appfunctions.service)
     ksp(libs.androidx.appfunctions.compiler)
 
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
 }
 
 // AppFunctions ksp option

--- a/ChatApp/wear/build.gradle.kts
+++ b/ChatApp/wear/build.gradle.kts
@@ -68,6 +68,9 @@ dependencies {
     implementation(libs.androidx.appfunctions)
     implementation(libs.androidx.appfunctions.service)
     ksp(libs.androidx.appfunctions.compiler)
+
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 }
 
 // AppFunctions ksp option


### PR DESCRIPTION
Use only endpoint for sendMessage and makeCall, because this is enough to uniquely identify a contact / group.

