### PR TITLE
Add .gitignore for ChatApp

### DIFF
--- a/ChatApp/.gitignore
+++ b/ChatApp/.gitignore
@@ -1,0 +1,43 @@
+# Gradle files
+.gradle/
+/gradle/gradle-daemon-jvm.properties
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.aab
+*.apk
+output-metadata.json
+
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof
+
+.instrumentation_output.txt
+
+.DS_Store
+
+# AI Agent Files
+.agents/
+AGENTS.md


### PR DESCRIPTION
Add .gitignore for ChatApp to avoid jvm properties being indexed 